### PR TITLE
Add support for reading bam files

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,8 +55,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"Kmer-hashing tools"
-copyright = u"2019, Chan Zuckerberg Biohub"
+project = "Kmer-hashing tools"
+copyright = "2019, Chan Zuckerberg Biohub"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -209,8 +209,8 @@ latex_documents = [
     (
         "index",
         "orpheum.tex",
-        u"orpheum Documentation",
-        u"Chan Zuckerberg Biohub",
+        "orpheum Documentation",
+        "Chan Zuckerberg Biohub",
         "manual",
     ),
 ]
@@ -241,7 +241,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ("index", "orpheum", u"Sencha Documentation", [u"Chan Zuckerberg Biohub"], 1)
+    ("index", "orpheum", "Sencha Documentation", ["Chan Zuckerberg Biohub"], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -257,8 +257,8 @@ texinfo_documents = [
     (
         "index",
         "orpheum",
-        u"Sencha Documentation",
-        u"Chan Zuckerberg Biohub",
+        "Sencha Documentation",
+        "Chan Zuckerberg Biohub",
         "orpheum",
         "Sencha is a Python package for directly translating RNA-seq reads into coding protein sequence.",
         "Miscellaneous",

--- a/orpheum/constants_index.py
+++ b/orpheum/constants_index.py
@@ -22,7 +22,7 @@ class BasedIntParamType(click.ParamType):
                 sigfig, exponent = value.split("e")
                 sigfig = float(sigfig)
                 exponent = int(exponent)
-                return int(sigfig * 10 ** exponent)
+                return int(sigfig * 10**exponent)
             return int(value, 10)
         except TypeError:
             self.fail(

--- a/orpheum/index.py
+++ b/orpheum/index.py
@@ -49,7 +49,7 @@ def per_read_false_positive_coding_rate(
     appears in the database"""
 
     alphabet_size = ALPHABET_SIZES[alphabet]
-    n_kmers_of_size = min(n_total_kmers, alphabet_size ** peptide_ksize)
+    n_kmers_of_size = min(n_total_kmers, alphabet_size**peptide_ksize)
 
     false_positive_rate = 0
     for frame in range(3):

--- a/orpheum/read_parser.py
+++ b/orpheum/read_parser.py
@@ -1,0 +1,56 @@
+import pysam
+import screed
+
+from orpheum.log_utils import get_logger
+logger = get_logger(__file__)
+
+
+class ReadParser:
+    """An abstraction of bam and fasta file format to simply return reads: ids and sequences"""
+
+    def __init__(self, filename, soft_clipping=False):
+        """
+
+        :param filename:
+        :param soft_clipping: bool
+            Applies to bam files only. If true, then return only the aligned segment of the read.
+            Doesn't return the bases that were "soft clipped"
+        """
+
+        self.filename = filename
+        self.soft_clipping = soft_clipping
+
+        try:
+            # Peek at the file with screed and see if it's a valid fasta/fastq format
+            # Use "with" so it closes automatically
+            with screed.open(self.filename) as _:
+                pass
+            self.filetype = 'fastx'
+            if self.soft_clipping:
+                logger.warn("soft_clipping set to 'True' on a fastq/fasta file, but "
+                            "this has no effect on these files")
+        except ValueError:
+            try:
+                pysam.AlignmentFile(self.filename)
+                self.filetype = 'bam'
+            except ValueError:
+                raise ValueError(f"Input file {self.filename} was not fastq/fasta or bam")
+
+    def __iter__(self):
+        if self.filetype == 'fastx':
+            return self._iter_reads_fastx()
+        elif self.filetype == "bam":
+            return self._iter_reads_bam()
+
+    def _iter_reads_fastx(self):
+        with screed.open(self.filename) as records:
+            for record in records:
+                yield record['name'], record['sequence']
+
+    def _iter_reads_bam(self):
+        bam = pysam.AlignmentFile(self.filename)
+        for record in bam:
+            yield record.qname, record.query_sequence
+
+
+

--- a/orpheum/read_parser.py
+++ b/orpheum/read_parser.py
@@ -2,6 +2,7 @@ import pysam
 import screed
 
 from orpheum.log_utils import get_logger
+
 logger = get_logger(__file__)
 
 
@@ -25,19 +26,23 @@ class ReadParser:
             # Use "with" so it closes automatically
             with screed.open(self.filename) as _:
                 pass
-            self.filetype = 'fastx'
+            self.filetype = "fastx"
             if self.soft_clipping:
-                logger.warn("soft_clipping set to 'True' on a fastq/fasta file, but "
-                            "this has no effect on these files")
+                logger.warn(
+                    "soft_clipping set to 'True' on a fastq/fasta file, but "
+                    "this has no effect on these files"
+                )
         except ValueError:
             try:
                 pysam.AlignmentFile(self.filename)
-                self.filetype = 'bam'
+                self.filetype = "bam"
             except ValueError:
-                raise ValueError(f"Input file {self.filename} was not fastq/fasta or bam")
+                raise ValueError(
+                    f"Input file {self.filename} was not fastq/fasta or bam"
+                )
 
     def __iter__(self):
-        if self.filetype == 'fastx':
+        if self.filetype == "fastx":
             return self._iter_reads_fastx()
         elif self.filetype == "bam":
             return self._iter_reads_bam()
@@ -45,12 +50,9 @@ class ReadParser:
     def _iter_reads_fastx(self):
         with screed.open(self.filename) as records:
             for record in records:
-                yield record['name'], record['sequence']
+                yield record["name"], record["sequence"]
 
     def _iter_reads_bam(self):
         bam = pysam.AlignmentFile(self.filename)
         for record in bam:
             yield record.qname, record.query_sequence
-
-
-

--- a/orpheum/sequence_encodings.py
+++ b/orpheum/sequence_encodings.py
@@ -468,7 +468,7 @@ def encode_peptide(peptide_sequence, molecule):
         )
 
 
-def get_best_kmer_size(sigma, n_items=20 ** 7):
+def get_best_kmer_size(sigma, n_items=20**7):
     """Get the best k-mer size for a particular alphabet
 
     This is going off of the fact that 7 is empirically the "best" k-mer

--- a/orpheum/translate.py
+++ b/orpheum/translate.py
@@ -374,7 +374,11 @@ class Translate:
         """Assign a coding score to each read. Where the magic happens."""
         parsed_reads = ReadParser(reads)
         # func = functools.partial(self.score_reads_per_record, read_name, read_seq)
-        scoring_lines = list(itertools.chain.from_iterable(map(self.score_reads_per_record, reads, parsed_reads)))
+        scoring_lines = list(
+            itertools.chain.from_iterable(
+                map(self.score_reads_per_record, reads, parsed_reads)
+            )
+        )
         return scoring_lines
 
     def set_coding_scores_all_files(self):
@@ -396,8 +400,8 @@ class Translate:
     default=None,
     type=int,
     help="K-mer size of the peptide sequence to use. Defaults for"
-         " different alphabets are, "
-         "protein: {}, dayhoff {}, hydrophobic-polar {}".format(
+    " different alphabets are, "
+    "protein: {}, dayhoff {}, hydrophobic-polar {}".format(
         constants_index.DEFAULT_PROTEIN_KSIZE,
         constants_index.DEFAULT_DAYHOFF_KSIZE,
         constants_index.DEFAULT_HP_KSIZE,
@@ -408,8 +412,8 @@ class Translate:
     is_flag=True,
     default=False,
     help="If specified, save the peptide bloom filter. "
-         "Default filename is the name of the fasta file plus a "
-         "suffix denoting the protein encoding and peptide ksize",
+    "Default filename is the name of the fasta file plus a "
+    "suffix denoting the protein encoding and peptide ksize",
 )
 @click.option(
     "--peptides-are-bloom-filter",
@@ -423,13 +427,13 @@ class Translate:
     type=click.FLOAT,
     callback=validate_jaccard,
     help="Minimum fraction of peptide k-mers from read in the "
-         "peptide database for this read to be called a "
-         "'coding read'.'"
-         "Default:"
-         "{}".format(constants_translate.DEFAULT_JACCARD_THRESHOLD)
-         + " for protein and dayhoff encodings, and "  # noqa
-         + "{}".format(constants_translate.DEFAULT_HP_JACCARD_THRESHOLD)  # noqa
-         + "for hydrophobic-polar (hp) encoding",  # noqa
+    "peptide database for this read to be called a "
+    "'coding read'.'"
+    "Default:"
+    "{}".format(constants_translate.DEFAULT_JACCARD_THRESHOLD)
+    + " for protein and dayhoff encodings, and "  # noqa
+    + "{}".format(constants_translate.DEFAULT_HP_JACCARD_THRESHOLD)  # noqa
+    + "for hydrophobic-polar (hp) encoding",  # noqa
 )
 @click.option(
     "--alphabet",
@@ -437,8 +441,8 @@ class Translate:
     "--molecule",
     default="protein",
     help="The type of amino acid encoding to use. Default is "
-         "'protein', but 'dayhoff' or 'hydrophobic-polar' can be "
-         "used",
+    "'protein', but 'dayhoff' or 'hydrophobic-polar' can be "
+    "used",
 )
 @click.option(
     "--csv",
@@ -449,15 +453,15 @@ class Translate:
     "--parquet",
     default=None,
     help="Name of parquet file to write with all sequence reads and "
-         "their coding scores. Parquet is a compressed version of csv, and is "
-         "recommended for larger datasets",
+    "their coding scores. Parquet is a compressed version of csv, and is "
+    "recommended for larger datasets",
 )
 @click.option(
     "--json-summary",
     default=None,
     help="Name of json file to write summarization of coding/"
-         "noncoding/other categorizations, the "
-         "min/max/mean/median/stddev of Jaccard scores, and other",
+    "noncoding/other categorizations, the "
+    "min/max/mean/median/stddev of Jaccard scores, and other",
 )
 @click.option(
     "--coding-nucleotide-fasta",
@@ -491,8 +495,8 @@ class Translate:
     "--long-reads",
     is_flag=True,
     help="If set, then only considers reading frames starting with "
-         "start codon (ATG) and ending in a stop codon "
-         "(TAG, TAA, TGA)",
+    "start codon (ATG) and ending in a stop codon "
+    "(TAG, TAA, TGA)",
 )
 @click.option("--verbose", is_flag=True, help="Print more output")
 def cli(

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ s3fs
 fastparquet
 pytest
 pytest-cov
+pysam

--- a/tests/test_read_parser.py
+++ b/tests/test_read_parser.py
@@ -1,0 +1,27 @@
+import os
+
+import pytest
+from orpheum.read_parser import ReadParser
+
+
+@pytest.fixture()
+def bamfile(data_folder):
+    basename = 'possorted_genome_bam__rbfox3_exon13_chr11_118494068-118494243.bam'
+    return os.path.join(data_folder, basename)
+
+
+def test_fasta(reads):
+    """Super simple test to make sure fastq/fasta parsing worked"""
+    readparser = ReadParser(reads)
+    for read_name, read_seq in readparser:
+        assert read_name == 'SRR306838.10559374 Ibis_Run100924_C3PO:6:51:17601:17119/1'
+        assert read_seq == 'CGCTTGCTTAATACTGACATCAATAATATTAGGAAAATCGCAATATAACTGTAAATCCTGTTCTGTC'
+        break
+
+def test_bam(bamfile):
+    """Super simple test to make sure bam/sam parsing worked"""
+    readparser = ReadParser(bamfile)
+    for read_name, read_seq in readparser:
+        assert read_name == 'NB501938:262:HG27TBGXK:3:12408:19165:6261'
+        assert read_seq == 'GCATTTGAGTGGCTGTTGCTCAGCTGCCATCTGGCACTTTGTCCCAAAGGTTCGTTTGCTCGCTCGGTTTCCTCTCATCCCCATGTACTC'
+        break

--- a/tests/test_read_parser.py
+++ b/tests/test_read_parser.py
@@ -6,7 +6,7 @@ from orpheum.read_parser import ReadParser
 
 @pytest.fixture()
 def bamfile(data_folder):
-    basename = 'possorted_genome_bam__rbfox3_exon13_chr11_118494068-118494243.bam'
+    basename = "possorted_genome_bam__rbfox3_exon13_chr11_118494068-118494243.bam"
     return os.path.join(data_folder, basename)
 
 
@@ -14,14 +14,21 @@ def test_fasta(reads):
     """Super simple test to make sure fastq/fasta parsing worked"""
     readparser = ReadParser(reads)
     for read_name, read_seq in readparser:
-        assert read_name == 'SRR306838.10559374 Ibis_Run100924_C3PO:6:51:17601:17119/1'
-        assert read_seq == 'CGCTTGCTTAATACTGACATCAATAATATTAGGAAAATCGCAATATAACTGTAAATCCTGTTCTGTC'
+        assert read_name == "SRR306838.10559374 Ibis_Run100924_C3PO:6:51:17601:17119/1"
+        assert (
+            read_seq
+            == "CGCTTGCTTAATACTGACATCAATAATATTAGGAAAATCGCAATATAACTGTAAATCCTGTTCTGTC"
+        )
         break
+
 
 def test_bam(bamfile):
     """Super simple test to make sure bam/sam parsing worked"""
     readparser = ReadParser(bamfile)
     for read_name, read_seq in readparser:
-        assert read_name == 'NB501938:262:HG27TBGXK:3:12408:19165:6261'
-        assert read_seq == 'GCATTTGAGTGGCTGTTGCTCAGCTGCCATCTGGCACTTTGTCCCAAAGGTTCGTTTGCTCGCTCGGTTTCCTCTCATCCCCATGTACTC'
+        assert read_name == "NB501938:262:HG27TBGXK:3:12408:19165:6261"
+        assert (
+            read_seq
+            == "GCATTTGAGTGGCTGTTGCTCAGCTGCCATCTGGCACTTTGTCCCAAAGGTTCGTTTGCTCGCTCGGTTTCCTCTCATCCCCATGTACTC"
+        )
         break


### PR DESCRIPTION
This adds a ReadParser class which abstracts away fastq/fasta vs bam/sam files and allows for translating bam files

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [x] If you've fixed a bug or added code that should be tested, add tests!
 - [x] Ensure the test suite passes with [pytest](https://docs.pytest.org/en/latest/) . (command to run: `pytest` or `make coverage` if you want to see which lines don't have tests yet)
 - [x] Make sure your code is linted and autoformatted using [black](https://github.com/psf/black) (`black . --check`).
 - [x] Documentation in `usage.md` is updated
 - [x] `README.md` is updated
